### PR TITLE
feat(azidentity): do not strip away request headers in doForClient

### DIFF
--- a/sdk/azidentity/CHANGELOG.md
+++ b/sdk/azidentity/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* `azidentity.doForClient` method no longer removes headers from the incoming request
 
 ### Other Changes
 

--- a/sdk/azidentity/azidentity.go
+++ b/sdk/azidentity/azidentity.go
@@ -151,6 +151,14 @@ func doForClient(client *azcore.Client, r *http.Request) (*http.Response, error)
 			return nil, err
 		}
 	}
+
+	h := req.Raw().Header
+	for key, val := range r.Header {
+		for i := range val {
+			h.Add(key, val[i])
+		}
+	}
+
 	resp, err := client.Pipeline().Do(req)
 	if err != nil {
 		return nil, err

--- a/sdk/azidentity/azidentity_test.go
+++ b/sdk/azidentity/azidentity_test.go
@@ -1068,6 +1068,11 @@ func TestDoForClient(t *testing.T) {
 					assert.Equal(t, string(reqBody), string(reqBody))
 				}
 
+				// validate headers match
+				for k, v := range tt.headers {
+					assert.Equal(t, v, req.Header[k])
+				}
+
 				// validate pipeline got called
 				assert.Equal(t, policyHeaderValue, req.Header.Get(policyHeaderName))
 

--- a/sdk/azidentity/azidentity_test.go
+++ b/sdk/azidentity/azidentity_test.go
@@ -7,11 +7,14 @@
 package azidentity
 
 import (
+	"bytes"
 	"context"
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -22,6 +25,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity/internal"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/recording"
@@ -29,6 +33,7 @@ import (
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/confidential"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/public"
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1001,6 +1006,103 @@ func TestTokenCachePersistenceOptions(t *testing.T) {
 	}
 }
 
+func TestDoForClient(t *testing.T) {
+	var (
+		policyHeaderName  = "PolicyHeader"
+		policyHeaderValue = "policyvalue"
+
+		reqBody  = []byte(`{"request": "azidentity"}`)
+		respBody = []byte(`{"response": "golang"}`)
+	)
+
+	tests := map[string]struct {
+		method  string
+		path    string
+		body    io.Reader
+		headers http.Header
+
+		wantErr bool
+	}{
+		"happy path": {
+			method: http.MethodGet,
+			path:   "/foo/bar",
+			body:   bytes.NewBuffer(reqBody),
+			headers: http.Header{
+				"Header": []string{"value1", "value2"},
+			},
+			wantErr: false,
+		},
+		"no body": {
+			method:  http.MethodGet,
+			path:    "/",
+			body:    http.NoBody,
+			wantErr: false,
+		},
+	}
+
+	client, err := azcore.NewClient(module, version, azruntime.PipelineOptions{
+		// add PerCall policy to ensure doForClient calls .Pipeline.Do()
+		PerCall: []policy.Policy{
+			policyFunc(func(req *policy.Request) (*http.Response, error) {
+				req.Raw().Header.Set(policyHeaderName, policyHeaderValue)
+				return req.Next()
+			}),
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	for name, tt := range tests {
+		tt := tt
+
+		t.Run(name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				// validate method matches
+				assert.Equal(t, tt.method, req.Method)
+
+				// validate path matches
+				assert.Equal(t, tt.path, req.URL.Path)
+
+				if req.Body != nil && req.Body != http.NoBody {
+					reqBody, err := io.ReadAll(req.Body)
+					assert.NoError(t, err)
+					assert.Equal(t, string(reqBody), string(reqBody))
+				}
+
+				// validate pipeline got called
+				assert.Equal(t, policyHeaderValue, req.Header.Get(policyHeaderName))
+
+				rw.Header().Set("content-type", "application/json")
+				_, err = rw.Write(respBody)
+				assert.NoError(t, err)
+			}))
+			defer server.Close()
+
+			req, err := http.NewRequestWithContext(context.Background(), tt.method, server.URL+tt.path, tt.body)
+			require.NoError(t, err)
+
+			for k, vs := range tt.headers {
+				for _, v := range vs {
+					req.Header.Add(k, v)
+				}
+			}
+
+			resp, err := doForClient(client, req)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			b, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			assert.Equal(t, string(respBody), string(b))
+		})
+	}
+}
+
 // ==================================================================================================================================
 
 type fakeConfidentialClient struct {
@@ -1098,3 +1200,12 @@ func (f fakePublicClient) AcquireTokenInteractive(ctx context.Context, scopes []
 }
 
 var _ msalPublicClient = (*fakePublicClient)(nil)
+
+// ==================================================================================================================================
+
+type policyFunc func(*policy.Request) (*http.Response, error)
+
+// Do implements the Policy interface on policyFunc.
+func (pf policyFunc) Do(req *policy.Request) (*http.Response, error) {
+	return pf(req)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
